### PR TITLE
Update e2e test for module support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
-FROM registry.fedoraproject.org/fedora:39
+FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf -y install vim
+RUN dnf -y install httpd-tools
 
-CMD ["vim", "--help"]
+CMD ["ab", "-V"]
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Cachi2 RPMs E2E test
 
-This scenario covers the prefetch and building of a Fedora 39 based container image that has `vim` installed from a set of RPMs. It provides two different sets of RPMs, one for x86_64 and the other for aarch64, as well as source RPMs.
+This scenario covers the prefetch and building of a UBI 8 based container image that has `httpd-tools` installed from a set of RPMs (including modular packages).
 
 The test steps are as follow:
-- prefetch the dependencies with Cachi2
+- prefetch the RPMs and module metadata with Cachi2
 - validate the prefetched output and the resulting SBOM
-- build an image hermetically with `vim` installed
+- build an image hermetically with `httpd-tools` and modular dependency packages installed

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1,62 +1,69 @@
+---
 lockfileVersion: 1
 lockfileVendor: redhat
 arches:
-  - arch: x86_64
-    packages:
-      - repoid: rpmfusion-free
-        url: https://download1.rpmfusion.org/free/fedora/releases/39/Everything/x86_64/os/Packages/l/libftl-0.9.14-12.fc39.x86_64.rpm
-        size: "41296"
-        checksum: sha256:6b0d8d3329150151fb8ea1eba7a4b464f112326777bee7a2e202753adc767281
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-data-9.0.1927-1.fc39.noarch.rpm
-        size: "23894"
-        checksum: sha256:35d7b9542e46eca30d951960effe9a8e738543a839f0dbb3cf723da0958c355b
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-minimal-9.0.1927-1.fc39.x86_64.rpm
-        size: "818364"
-        checksum: sha256:37a216f1af9f2eb961a9fa6674861146d11ca56fc9c576fa17a8cb7d806aa0af
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/g/gpm-libs-1.20.7-44.fc39.x86_64.rpm
-        size: "20720"
-        checksum: sha256:f5c8f20f0f9468da8cdf140d7df30ed117a43b73eee816888e2624b0fcd048ca
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/l/libsodium-1.0.18-14.fc39.x86_64.rpm
-        size: "165965"
-        checksum: sha256:e38200a7b1012935dc83e8039c71c0fd2f84a4463ca086cb42f60f488cdad8e7
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-common-9.0.1927-1.fc39.x86_64.rpm
-        size: "7784784"
-        checksum: sha256:4cb8015a858439f519d5d2aa82fd853f3d1dd7f927a33d25d9598e54ee6201bc
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-enhanced-9.0.1927-1.fc39.x86_64.rpm
-        size: "1950948"
-        checksum: sha256:615d46a08fbbd0eca6a6e8d2d23a6b5847db11c886e0dc979ffebab66236532d
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-filesystem-9.0.1927-1.fc39.noarch.rpm
-        size: "18444"
-        checksum: sha256:f645ed8cda2fa07ba991320a684d9b71de75ff25220468b08fb36f6a5a231178
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/w/which-2.21-40.fc39.x86_64.rpm
-        size: "42835"
-        checksum: sha256:ec1d8a1c0d88883a03e96ba88a6278899bd559fb37833cb2383ffdd6a38c22ae
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/x/xxd-9.0.1927-1.fc39.x86_64.rpm
-        size: "37332"
-        checksum: sha256:e770b0a0e5e51225a76069d2210551a90f3140913f90f33759d002055179ecc7
-    source:
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/source/tree/Packages/v/vim-9.0.1927-1.fc39.src.rpm
-        size: "14382769"
-        checksum: sha256:dae76267f265093d0e1b178c05af197bc21b994a264c9c4e7701cce095b62f03
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/source/tree/Packages/g/gpm-1.20.7-44.fc39.src.rpm
-        size: "251337"
-        checksum: sha256:2eb2412dde91b1130433c90ad53b889cb1e0fb0df324e015f29e76d7235ac438
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/source/tree/Packages/l/libsodium-1.0.18-14.fc39.src.rpm
-        size: "1953916"
-        checksum: sha256:d20e5f6e358aa0c07260872ffb00d502f77778ae7496a836da0a65a6ce1cd709
-      - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/source/tree/Packages/w/which-2.21-40.fc39.src.rpm
-        size: "182684"
-        checksum: sha256:791428d30c136a2ff8e781b9c32cbd3d506699f1369ae2a589c02fceb72d4533
+- arch: x86_64
+  packages:
+  - repoid: rpmfusion-free
+    url: https://download1.rpmfusion.org/free/el/updates/8/x86_64/l/libftl-0.9.14-2.el8.x86_64.rpm
+    size: "15736"
+    checksum: sha256:614ae89e55ae2adabbba474eaea2e60c9bf00ff0c1ab55d529788fcf11e720ab
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/apr-1.6.3-12.el8.x86_64.rpm
+    repoid: ubi-8-appstream-rpms
+    size: 132644
+    checksum: sha256:4be7cfbb58aeec0db66ac9d2e996de662499bac99a2788f934f87d6998ba073e
+    name: apr
+    evr: 1.6.3-12.el8
+    sourcerpm: apr-1.6.3-12.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/apr-util-1.6.1-9.el8.x86_64.rpm
+    repoid: ubi-8-appstream-rpms
+    size: 108280
+    checksum: sha256:153b5f51d3e71191b5ccd483298911aeb9a0794cc9d8f13ae22cac8c5b3643e3
+    name: apr-util
+    evr: 1.6.1-9.el8
+    sourcerpm: apr-util-1.6.1-9.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/apr-util-bdb-1.6.1-9.el8.x86_64.rpm
+    repoid: ubi-8-appstream-rpms
+    size: 25604
+    checksum: sha256:106ed56188f62702d967d3148b05ef2f0e43fceee7b2bc3d44dd53be20a300b5
+    name: apr-util-bdb
+    evr: 1.6.1-9.el8
+    sourcerpm: apr-util-1.6.1-9.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/apr-util-openssl-1.6.1-9.el8.x86_64.rpm
+    repoid: ubi-8-appstream-rpms
+    size: 27864
+    checksum: sha256:bb636fb6d64af9e9a9b3f432dd587d60946c987b31758c59a20a0d7872099c14
+    name: apr-util-openssl
+    evr: 1.6.1-9.el8
+    sourcerpm: apr-util-1.6.1-9.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/h/httpd-tools-2.4.37-65.module+el8.10.0+22196+d82931da.2.x86_64.rpm
+    repoid: ubi-8-appstream-rpms
+    size: 115095
+    checksum: sha256:2b650ff7cfb275f157f849f7dc7883c4f7b9bf9f8d89e10a1406c4d7802b3387
+    name: httpd-tools
+    evr: 2.4.37-65.module+el8.10.0+22196+d82931da.2
+    sourcerpm: httpd-2.4.37-65.module+el8.10.0+22196+d82931da.2.src.rpm
+  source:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/source/SRPMS/Packages/a/apr-1.6.3-12.el8.src.rpm
+    repoid: ubi-8-appstream-source
+    size: 889739
+    checksum: sha256:31c1ce68fb74c6426ac6270f0f255199daffc9000897343efcdff0a41e914f9d
+    name: apr
+    evr: 1.6.3-12.el8
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/source/SRPMS/Packages/a/apr-util-1.6.1-9.el8.src.rpm
+    repoid: ubi-8-appstream-source
+    size: 461075
+    checksum: sha256:3a7dec001ee63a28de3f1609a4b3da03ec9c8eda3f6802fe491cf456be267e82
+    name: apr-util
+    evr: 1.6.1-9.el8
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/source/SRPMS/Packages/h/httpd-2.4.37-65.module+el8.10.0+22196+d82931da.2.src.rpm
+    repoid: ubi-8-appstream-source
+    size: 7319132
+    checksum: sha256:bc1c91f3fce3452aa7dba9810592cf2a40957ef5d3b2d23a96c1853365425c50
+    name: httpd
+    evr: 2.4.37-65.module+el8.10.0+22196+d82931da.2
+  module_metadata:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/repodata/f8b0c07e33ebd4bf5b9b3dea1f0c0f72acb0ea1e0bf07af663eb11b661ef49a6-modules.yaml.gz
+    repoid: ubi-8-appstream-rpms
+    size: 59506
+    checksum: sha256:f8b0c07e33ebd4bf5b9b3dea1f0c0f72acb0ea1e0bf07af663eb11b661ef49a6


### PR DESCRIPTION
UBI base image is used since modularity has been dropped in Fedora 39+.

This test case verifies the prefetching of RPMs and module metadata, as well as the installation of both regular and modular packages.