### PR TITLE
rpms.lock.yaml: Change the mirror domain to the dl.fedoraproject.org one

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -8,55 +8,55 @@ arches:
         size: "41296"
         checksum: sha256:6b0d8d3329150151fb8ea1eba7a4b464f112326777bee7a2e202753adc767281
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-data-9.0.1927-1.fc39.noarch.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-data-9.0.1927-1.fc39.noarch.rpm
         size: "23894"
         checksum: sha256:35d7b9542e46eca30d951960effe9a8e738543a839f0dbb3cf723da0958c355b
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-minimal-9.0.1927-1.fc39.x86_64.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-minimal-9.0.1927-1.fc39.x86_64.rpm
         size: "818364"
         checksum: sha256:37a216f1af9f2eb961a9fa6674861146d11ca56fc9c576fa17a8cb7d806aa0af
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/g/gpm-libs-1.20.7-44.fc39.x86_64.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/g/gpm-libs-1.20.7-44.fc39.x86_64.rpm
         size: "20720"
         checksum: sha256:f5c8f20f0f9468da8cdf140d7df30ed117a43b73eee816888e2624b0fcd048ca
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/l/libsodium-1.0.18-14.fc39.x86_64.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/l/libsodium-1.0.18-14.fc39.x86_64.rpm
         size: "165965"
         checksum: sha256:e38200a7b1012935dc83e8039c71c0fd2f84a4463ca086cb42f60f488cdad8e7
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-common-9.0.1927-1.fc39.x86_64.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-common-9.0.1927-1.fc39.x86_64.rpm
         size: "7784784"
         checksum: sha256:4cb8015a858439f519d5d2aa82fd853f3d1dd7f927a33d25d9598e54ee6201bc
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-enhanced-9.0.1927-1.fc39.x86_64.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-enhanced-9.0.1927-1.fc39.x86_64.rpm
         size: "1950948"
         checksum: sha256:615d46a08fbbd0eca6a6e8d2d23a6b5847db11c886e0dc979ffebab66236532d
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/v/vim-filesystem-9.0.1927-1.fc39.noarch.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/v/vim-filesystem-9.0.1927-1.fc39.noarch.rpm
         size: "18444"
         checksum: sha256:f645ed8cda2fa07ba991320a684d9b71de75ff25220468b08fb36f6a5a231178
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/w/which-2.21-40.fc39.x86_64.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/w/which-2.21-40.fc39.x86_64.rpm
         size: "42835"
         checksum: sha256:ec1d8a1c0d88883a03e96ba88a6278899bd559fb37833cb2383ffdd6a38c22ae
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/x86_64/os/Packages/x/xxd-9.0.1927-1.fc39.x86_64.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/Packages/x/xxd-9.0.1927-1.fc39.x86_64.rpm
         size: "37332"
         checksum: sha256:e770b0a0e5e51225a76069d2210551a90f3140913f90f33759d002055179ecc7
     source:
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/source/tree/Packages/v/vim-9.0.1927-1.fc39.src.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/source/tree/Packages/v/vim-9.0.1927-1.fc39.src.rpm
         size: "14382769"
         checksum: sha256:dae76267f265093d0e1b178c05af197bc21b994a264c9c4e7701cce095b62f03
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/source/tree/Packages/g/gpm-1.20.7-44.fc39.src.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/source/tree/Packages/g/gpm-1.20.7-44.fc39.src.rpm
         size: "251337"
         checksum: sha256:2eb2412dde91b1130433c90ad53b889cb1e0fb0df324e015f29e76d7235ac438
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/source/tree/Packages/l/libsodium-1.0.18-14.fc39.src.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/source/tree/Packages/l/libsodium-1.0.18-14.fc39.src.rpm
         size: "1953916"
         checksum: sha256:d20e5f6e358aa0c07260872ffb00d502f77778ae7496a836da0a65a6ce1cd709
       - repoid: releases
-        url: http://fedora.c3sl.ufpr.br/linux/releases/39/Everything/source/tree/Packages/w/which-2.21-40.fc39.src.rpm
+        url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Everything/source/tree/Packages/w/which-2.21-40.fc39.src.rpm
         size: "182684"
         checksum: sha256:791428d30c136a2ff8e781b9c32cbd3d506699f1369ae2a589c02fceb72d4533


### PR DESCRIPTION
This was originally set to a Brazilian mirror and recently it caused CI issues. Replace it with the master mirror dl.fedoraproject.org which is a DNS ring buffer to a few Fedora owned servers [1].

[1] https://fedoraproject.org/wiki/Infrastructure/Mirroring/Tiering#Master_mirrors